### PR TITLE
Propose a different way to organize the code

### DIFF
--- a/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/BaseOutputtingCommand.cs
@@ -1067,7 +1067,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                         alignment[k] = TextAlignment.Left; // hard coded default
                     }
                 }
-                this.Writer.GenerateRow(values, this.InnerCommand._lo, tre.multiLine, alignment, InnerCommand._lo.DisplayCells);
+                this.Writer.GenerateRow(values, this.InnerCommand._lo, tre.multiLine, alignment, InnerCommand._lo.DisplayCells, generatedRows: null);
                 _rowCount++;
             }
 
@@ -1278,7 +1278,7 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                     else
                         values[k] = string.Empty;
                 }
-                this.Writer.GenerateRow(values, this.InnerCommand._lo, false, null, InnerCommand._lo.DisplayCells);
+                this.Writer.GenerateRow(values, this.InnerCommand._lo, false, null, InnerCommand._lo.DisplayCells, generatedRows: null);
                 _buffer.Reset();
             }
 

--- a/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
+++ b/src/System.Management.Automation/FormatAndOutput/common/TableWriter.cs
@@ -158,10 +158,10 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 return _header.Count;
             }
 
-            var header = new List<string>();
+            _header = new List<string>();
 
             // generate the row with the header labels
-            header = GenerateRow(values, lo, true, null, lo.DisplayCells);
+            GenerateRow(values, lo, true, null, lo.DisplayCells, _header);
 
             // generate an array of "--" as header markers below
             // the column header labels
@@ -188,17 +188,14 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
                 breakLine[k] = StringUtil.DashPadding(count);
             }
 
-            header.AddRange(GenerateRow(breakLine, lo, false, null, lo.DisplayCells));
-            _header = header;
+            GenerateRow(breakLine, lo, false, null, lo.DisplayCells, _header);
             return _header.Count;
         }
 
-        internal List<string> GenerateRow(string[] values, LineOutput lo, bool multiLine, ReadOnlySpan<int> alignment, DisplayCells dc)
+        internal void GenerateRow(string[] values, LineOutput lo, bool multiLine, ReadOnlySpan<int> alignment, DisplayCells dc, List<string> generatedRows)
         {
-            List<string> lines = new List<string>();
-
             if (_disabled)
-                return lines;
+                return;
 
             // build the current row alignment settings
             int cols = _si.columnInfo.Length;
@@ -226,18 +223,15 @@ namespace Microsoft.PowerShell.Commands.Internal.Format
             {
                 foreach (string line in GenerateTableRow(values, currentAlignment, lo.DisplayCells))
                 {
-                    lines.Add(line);
+                    generatedRows?.Add(line);
                     lo.WriteLine(line);
                 }
-
-                return lines;
             }
             else
             {
                 string line = GenerateRow(values, currentAlignment, dc);
+                generatedRows?.Add(line);
                 lo.WriteLine(line);
-                lines.Add(line);
-                return lines;
             }
         }
 


### PR DESCRIPTION
Propose a different way to organize the code in `GenerateRow`. The method is called in `ProcessPayload` where we don't care about capturing all generated rows, so we should avoid creating a list every time the method is called. The proposed way can minimize list allocation and avoid a potential perf regression.